### PR TITLE
Fix caching of suggested categories.

### DIFF
--- a/module/scripts/index/category-suggest.js
+++ b/module/scripts/index/category-suggest.js
@@ -84,7 +84,6 @@
               self.input.data("request.count.suggest", calls);
             },
             success: function(data) {
-              $.suggest.cache[url] = data;
               // translate the results of the Commons API to that of the reconciliation API
               var translated = {
                   prefix: val, // keep track of prefix to match up response with input value
@@ -93,6 +92,7 @@
                       name: result
                     };})
               };
+              $.suggest.cache[url] = translated;
               self.response(translated, cursor ? cursor : -1);
             },
             error: function(xhr) {


### PR DESCRIPTION
This is a fix similar to https://github.com/OpenRefine/OpenRefine/pull/5328, since this code was inspired from the Wikibase extension.

The problem was that responses were cached before being translated to the common format understood by the suggest library, and when they were restored from the cache they would not be translated, which would result in them not being processed properly down the line.