### PR TITLE
allow lossy rendering of thumbnails

### DIFF
--- a/module/scripts/project/thumbnail-renderer.js
+++ b/module/scripts/project/thumbnail-renderer.js
@@ -120,7 +120,7 @@ class ThumbnailReconRenderer extends ReconCellRenderer {
    See https://www.mediawiki.org/wiki/Requests_for_comment/Standardized_thumbnails_sizes
    */
   getThumbnailUrl(mediaWikiRootUrl, bareFileName, width) {
-     return `${mediaWikiRootUrl}w/thumb.php?f=${encodeURIComponent(bareFileName)}&w=${width}&h=${width}`;
+     return `${mediaWikiRootUrl}w/thumb.php?f=${encodeURIComponent(bareFileName)}&w=${width}&h=${width}&lossy=lossy`;
   }
 }
 


### PR DESCRIPTION
The ´lossy´ parameter just states if lossy rendering is allowed or not so it's safe to add it to all thumb.php requests.

The change should solve rendering issues for JPEG, PNG, TIFF, and possibly other formats.