### PR TITLE
Remove reference to the file macros.vm in module.properties

### DIFF
--- a/module/MOD-INF/module.properties
+++ b/module/MOD-INF/module.properties
@@ -1,4 +1,3 @@
 name = commons
 description = Integration with Wikimedia Commons
-templating.macros = macros.vm
 requires = core


### PR DESCRIPTION
This was causing errors when loading the extension because the file didn't exist.

Fixes: #101