### PR TITLE
Issue 94 File thumbnails don't show up after upload of new files

### DIFF
--- a/module/scripts/project/thumbnail-renderer.js
+++ b/module/scripts/project/thumbnail-renderer.js
@@ -61,7 +61,7 @@ class ThumbnailReconRenderer extends ReconCellRenderer {
         .attr("target", "_blank")
         .appendTo(divContentRecon);
 
-      var bareFileName = match.name.substr('File:'.length).replaceAll(' ', '_');
+      var bareFileName = match.name.includes('File:') ? match.name.substr('File:'.length).replaceAll(' ', '_') : match.name.replaceAll(' ', '_');
       var fileNameParts = bareFileName.split('.');
       var extension = fileNameParts[fileNameParts.length - 1].toLowerCase();
       if (!self.supportedExtensions.includes(extension)) {


### PR DESCRIPTION
Issue - [94](https://github.com/OpenRefine/CommonsExtension/issues/94)
Media preview fails to load in case of new data as the newly added data do not contain the prefix "File:".
Updated code to handle the scenario of missing prefix "Fiile:" 