### PR TITLE
ui: give the depth input a static width

### DIFF
--- a/module/styles/commons-importing-controller.less
+++ b/module/styles/commons-importing-controller.less
@@ -56,7 +56,7 @@ div.grid-layout > table.categoriesTable > tbody > tr > td.depth-input-td {
 }
 
 .depth-input-box {
-  width: 30%;
+  width: 30px;
 }
 .x-button-td {
   text-align: left;


### PR DESCRIPTION
Given that the depth can be a value from 0-6 we know that the useful width of this element will always be the same. The past value (30%) would cause the element to sometimes become wider than necessary while sometimes also shrinking to a size in which it would no longer be possible to see the input value.